### PR TITLE
Open output CSV using `utf-8` to avoid unicode error

### DIFF
--- a/src/file.py
+++ b/src/file.py
@@ -14,7 +14,7 @@ def unzip_file(f):
 
 def save_to_csv(f):
     try:
-        with open(f, 'w', newline='') as file:
+        with open(f, 'w', newline='', encoding='utf-8') as file:
             tempfile = db.connect('tempfile')
             writer = csv.writer(file, quotechar='"', quoting=csv.QUOTE_MINIMAL)
             


### PR DESCRIPTION
I got an error when trying to extract an apkg with unicode characters - this fixed it.

Error: `'charmap' codec can't encode character '\u0108' in position 63: character maps to <undefined>`

Input file: https://ankiweb.net/shared/info/353142617